### PR TITLE
Fix issue causing diagram to be stretched vertically in web docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,6 @@ Metagenome Assembled Genomes Workflow (v1.3.9)
 =============================================
 
 .. image:: mags_workflow2024.png
-   :scale: 65%
    :alt: Metagenome assembled genomes generation 
 
 


### PR DESCRIPTION
In this branch, I made it so that, instead of the diagram being stretched vertically; like this:

![image](https://github.com/user-attachments/assets/252154ae-5d2c-4c44-a5b8-13ba16476ae8)

It will be displayed with its native proportions; like this:

![image](https://github.com/user-attachments/assets/b9859950-ba10-4503-90b5-c90af9caeecb)

Fixes #58 