### PR TITLE
Configure "Edit on GitHub" link by adding `:github_url:` field to `index.rst` file

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,12 @@
 :github_url: https://github.com/microbiomedata/metaMAGs/blob/master/docs/index.rst
 
+..
+   Note: The above `github_url` field is used to force the target of the "Edit on GitHub" link
+         to be the specified URL. That makes it so that link still works even when this source
+         file is incorporated into a different website. You can learn more about the field at:
+         https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-github_url
+
+
 Metagenome Assembled Genomes Workflow (v1.3.9)
 =============================================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/microbiomedata/metaMAGs/blob/master/docs/index.rst
+
 Metagenome Assembled Genomes Workflow (v1.3.9)
 =============================================
 


### PR DESCRIPTION
In this PR, I made it so that — when the documentation source file from this repo is pulled into the centralized documentation website (implemented in the `docs` repo) and built into a web page — the "Edit on GitHub" link on that web page points to the correct source file on GitHub.